### PR TITLE
add title and extension to license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+##ISC License
+
 Copyright (c) 2015, George Lee
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.


### PR DESCRIPTION
The title is not strictly required, but it's useful metadata, and part of the recommended license template text (see http://choosealicense.com/licenses/isc, https://opensource.org/licenses/isc-license and http://spdx.org/licenses/ISC.html#licenseText)

The extension helps with the display of the license on github (it activates text wrapping)
